### PR TITLE
show *all* mlint messages

### DIFF
--- a/src/matlabDiagnostics.ts
+++ b/src/matlabDiagnostics.ts
@@ -29,7 +29,7 @@ export function check(filename: string, lintOnSave = true, mlintPath = ""): Prom
 
 		cp.execFile(
 			mlintPath,
-			[filename],
+			['-all', filename],
 			{ encoding: 'buffer' },
 			(err: Error, stdout, stderr) => {
 				try {


### PR DESCRIPTION
without the '-all' flag mlint does not pick up on capitalization differences between function name and file name.